### PR TITLE
Remove newline character in user input

### DIFF
--- a/input_ui.go
+++ b/input_ui.go
@@ -29,6 +29,7 @@ func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
 			if err != nil {
 				Debugf("Failed to scan stdin: %s", err.Error())
 			}
+			line = strings.TrimSuffix(line, "\n")
 
 			Debugf("Input: %q", line)
 


### PR DESCRIPTION
I encountered error as follow.
It seems that `line` in `line, err := reader.ReadString('\n')` contains newline character(`\n`) ( https://golang.org/pkg/bufio/#Reader.ReadString).
So,  I added a code that trims the newline character from `line`

```
$ license
Which of the following do you want to use?
   1) GNU General Public License v3.0
...
  15) GNU Lesser General Public License v2.1
Your choice? [default: 13] 2
  is not a valid choice. Choose by number.
``
```
