### PR TITLE
UI improvements and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,37 +8,37 @@
 [license]: https://github.com/tcnksm/license/blob/master/LICENSE
 [godocs]: http://godoc.org/github.com/tcnksm/license
 
-`license` is a simple command line tool to generate LICENSE file you want to use. It fetches one from [Github API](https://developer.github.com/v3/licenses/). You can also choose LICENSE like [choosealicense.com](http://choosealicense.com/). 
+`license` is a simple command line tool to generate LICENSE files you want to use. They are fetched from [GitHub API](https://developer.github.com/v3/licenses/). You can also choose LICENSE like [choosealicense.com](http://choosealicense.com/).
 
 ## Demo
 
-You can select a LICENSE from available list,
+You can select a LICENSE from an available list,
 
 ![](http://g.recordit.co/IlnUBhCUHX.gif)
 
-You can just provide key name,
+You can just provide a key name,
 
 ![](http://g.recordit.co/FRKXgTvrml.gif)
 
-If you feel difficulty to choose LICENSE, you can do it like [choosealicense.com](http://choosealicense.com/),
+If you feel difficulty in choosing LICENSE, you can do it like [choosealicense.com](http://choosealicense.com/),
 
 ![](http://g.recordit.co/2MZs3RTnSd.gif)
 
 ## Usage
 
-To generate LICENSE file, you just provide `KEY` name of LICENSE you want,
+To generate a LICENSE file, just provide a `KEY` name of a LICENSE you want,
 
 ```bash
 $ license [option] [KEY]
 ```
 
-To check available `LICENSE` file and its `KEY`, you can see all of them by `-list` option, 
+To check available `LICENSE`s and their `KEY`s, you can see all of them by `-list` option,
 
 ```bash
 $ license -list
 ```
 
-If you don't provide specific `KEY`, `license` will ask you to select one from list.
+If you don't provide any specific `KEY`, `license` will ask you to select one from a list.
 
 To choose LICENSE like [choosealicense.com](http://choosealicense.com/),
 
@@ -46,13 +46,13 @@ To choose LICENSE like [choosealicense.com](http://choosealicense.com/),
 $ license -choose
 ```
 
-To see more usage, use `-help` option
+To see more usage, use `-help` option.
 
-## Install 
+## Install
 
-Binaries for your platform are provided, install it from [Release page](https://github.com/tcnksm/license/releases).
+Binaries for your platform are provided, install them from [Release page](https://github.com/tcnksm/license/releases).
 
-If you use OSX and [homebrew](http://brew.sh/) for your package manager, you can use formula for this project,
+If you use macOS and manage packages with [Homebrew](http://brew.sh/), you can use a formula for this project,
 
 ```bash
 $ brew tap tcnksm/license

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Demo
 
-You can select a LICENSE from avairable list,
+You can select a LICENSE from available list,
 
 ![](http://g.recordit.co/IlnUBhCUHX.gif)
 

--- a/cache.go
+++ b/cache.go
@@ -82,14 +82,14 @@ func getCache(key, path string) (string, error) {
 func cleanCache(key, path string) {
 	oldCacheFiles, err := filepath.Glob(filepath.Join(path, key+"-"+"*"))
 	if err != nil {
-		Debugf("Failed to glob cache files: %s", err.Error())
+		Debugf("Failed to glob cache files: %s", err)
 	}
 
 	for _, of := range oldCacheFiles {
 		Debugf("Delete old cache file: %s", of)
 		err := os.Remove(of)
 		if err != nil {
-			Debugf("Failed to delete old cache file %s: %s", of, err.Error())
+			Debugf("Failed to delete old cache file %s: %s", of, err)
 		}
 	}
 }

--- a/cli.go
+++ b/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"flag"
@@ -150,7 +151,7 @@ func (cli *CLI) Run(args []string) int {
 		}
 
 		// Write LICENSE list as a table
-		outBuffer := new(bytes.Buffer)
+		outBuffer := bufio.NewWriterSize(cli.outStream, 1024)
 		table := tablewriter.NewWriter(outBuffer)
 
 		header := []string{"Key", "Name"}
@@ -162,7 +163,7 @@ func (cli *CLI) Run(args []string) int {
 		table.Render()
 
 		outBuffer.WriteString("See more about these LICENSE at http://choosealicense.com/licenses/\n")
-		fmt.Fprintf(cli.outStream, outBuffer.String())
+		outBuffer.Flush()
 
 		return ExitCodeOK
 	}
@@ -211,12 +212,12 @@ func (cli *CLI) Run(args []string) int {
 			return *list[i].Name < *list[j].Name
 		})
 
-		var buf bytes.Buffer
+		buf := bufio.NewWriterSize(cli.errStream, 512)
 		buf.WriteString("Which of the following do you want to use?\n")
 		for i, l := range list {
-			fmt.Fprintf(&buf, "  %2d) %s\n", i+1, *l.Name)
+			fmt.Fprintf(buf, "  %2d) %s\n", i+1, *l.Name)
 		}
-		cli.errorf(buf.String())
+		buf.Flush()
 
 		// Use MIT as default, it may change in future
 		// So should fix it

--- a/cli.go
+++ b/cli.go
@@ -212,16 +212,20 @@ func (cli *CLI) Run(args []string) int {
 			return *list[i].Name < *list[j].Name
 		})
 
+		// Will be a number corresponding to MIT, but not guaranteed
+		var defaultNum int
+
 		buf := bufio.NewWriterSize(cli.errStream, 512)
 		buf.WriteString("Which of the following do you want to use?\n")
 		for i, l := range list {
 			fmt.Fprintf(buf, "  %2d) %s\n", i+1, *l.Name)
+
+			// Use MIT as default
+			if *l.Key == "mit" {
+				defaultNum = i + 1
+			}
 		}
 		buf.Flush()
-
-		// Use MIT as default, it may change in future
-		// So should fix it
-		defaultNum := 13
 
 		num, err := cli.AskNumber(len(list), defaultNum)
 		if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -301,17 +301,29 @@ func (cli *CLI) Run(args []string) int {
 		if len(defaultAuthor) == 0 {
 			defaultAuthor = DoNothing
 		}
-		body = cli.ReplacePlaceholder(body, nameKeys, "Input author name", defaultAuthor, optionAuthor)
+		body, err = cli.ReplacePlaceholder(body, nameKeys, "Input author name", defaultAuthor, optionAuthor)
+		if err != nil {
+			fmt.Fprintf(cli.errStream, "%s\n", err)
+			return ExitCodeError
+		}
 
 		// Replace email if needed
 		defaultEmail, _ := gitconfig.Email()
 		if len(defaultEmail) == 0 {
 			defaultEmail = DoNothing
 		}
-		body = cli.ReplacePlaceholder(body, nameKeys, "Input email", defaultEmail, optionEmail)
+		body, err = cli.ReplacePlaceholder(body, nameKeys, "Input email", defaultEmail, optionEmail)
+		if err != nil {
+			fmt.Fprintf(cli.errStream, "%s\n", err)
+			return ExitCodeError
+		}
 
 		// Replace project name if needed
-		body = cli.ReplacePlaceholder(body, projectKeys, "Input project name", DoNothing, optionProject)
+		body, err = cli.ReplacePlaceholder(body, projectKeys, "Input project name", DoNothing, optionProject)
+		if err != nil {
+			fmt.Fprintf(cli.errStream, "%s\n", err)
+			return ExitCodeError
+		}
 	}
 
 	// Write LICENSE body to file

--- a/cli.go
+++ b/cli.go
@@ -269,20 +269,6 @@ func (cli *CLI) Run(args []string) int {
 		fetched = true
 	}
 
-	// Create output path if it is not exist
-	dir, _ := filepath.Split(output)
-	if len(dir) != 0 {
-		os.MkdirAll(dir, 0777)
-	}
-
-	licenseWriter, err := os.Create(output)
-	if err != nil {
-		cli.errorf("Failed to create file %s: %s\n", output, err.Error())
-		return ExitCodeError
-	}
-	defer licenseWriter.Close()
-	Debugf("Output filename: %s", output)
-
 	// Replace place holders
 	if !raw {
 		s, err := cli.runReplace(DefaultValue, body, replacement{
@@ -297,6 +283,20 @@ func (cli *CLI) Run(args []string) int {
 		}
 		body = s
 	}
+
+	// Create the output directory if necessary
+	dir, _ := filepath.Split(output)
+	if len(dir) != 0 {
+		os.MkdirAll(dir, 0777)
+	}
+
+	licenseWriter, err := os.Create(output)
+	if err != nil {
+		cli.errorf("Failed to create file %s: %s\n", output, err.Error())
+		return ExitCodeError
+	}
+	defer licenseWriter.Close()
+	Debugf("Output filename: %s", output)
 
 	// Write LICENSE body to file
 	_, err = io.Copy(licenseWriter, strings.NewReader(body))

--- a/cli.go
+++ b/cli.go
@@ -130,7 +130,7 @@ func (cli *CLI) Run(args []string) int {
 		// Fetch list from GitHub API
 		list, res, err := client.Licenses.List(context.Background())
 		if err != nil {
-			cli.errorf("Failed to fetch LICENSE list: %s\n", err.Error())
+			cli.errorf("Failed to fetch LICENSE list: %s\n", err)
 			return ExitCodeError
 		}
 
@@ -192,7 +192,7 @@ func (cli *CLI) Run(args []string) int {
 		var err error
 		key, err = cli.Choose()
 		if err != nil {
-			cli.errorf("Failed to choose a LICENSE: %s\n", err.Error())
+			cli.errorf("Failed to choose a LICENSE: %s\n", err)
 			return ExitCodeError
 		}
 	}
@@ -203,7 +203,7 @@ func (cli *CLI) Run(args []string) int {
 
 		list, err := fetchLicenseList()
 		if err != nil {
-			cli.errorf("Failed to show LICENSE list: %s", err.Error())
+			cli.errorf("Failed to show LICENSE list: %s", err)
 			return ExitCodeError
 		}
 
@@ -224,7 +224,7 @@ func (cli *CLI) Run(args []string) int {
 
 		num, err := cli.AskNumber(len(list), defaultNum)
 		if err != nil {
-			cli.errorf("Failed to scan user input: %s\n", err.Error())
+			cli.errorf("Failed to scan user input: %s\n", err)
 			return ExitCodeError
 		}
 
@@ -233,7 +233,7 @@ func (cli *CLI) Run(args []string) int {
 
 	home, err := homedir.Dir()
 	if err != nil {
-		Debugf("Failed to get home directory: %s", err.Error())
+		Debugf("Failed to get home directory: %s", err)
 		noCache = true
 		home = "."
 	}
@@ -245,7 +245,7 @@ func (cli *CLI) Run(args []string) int {
 		var err error
 		body, err = getCache(key, cacheDir)
 		if err != nil {
-			Debugf("Failed to get cache: %s", err.Error())
+			Debugf("Failed to get cache: %s", err)
 		}
 	}
 
@@ -255,14 +255,14 @@ func (cli *CLI) Run(args []string) int {
 		var err error
 		body, err = fetchLicense(key)
 		if err != nil {
-			cli.errorf("Failed to get LICENSE file: %s\n", err.Error())
+			cli.errorf("Failed to get LICENSE file: %s\n", err)
 			return ExitCodeError
 		}
 
 		if !noCache {
 			err := setCache(body, key, cacheDir)
 			if err != nil {
-				Debugf("Failed to save cache: %s", err.Error())
+				Debugf("Failed to save cache: %s", err)
 			}
 		}
 
@@ -292,7 +292,7 @@ func (cli *CLI) Run(args []string) int {
 
 	licenseWriter, err := os.Create(output)
 	if err != nil {
-		cli.errorf("Failed to create file %s: %s\n", output, err.Error())
+		cli.errorf("Failed to create file %s: %s\n", output, err)
 		return ExitCodeError
 	}
 	defer licenseWriter.Close()
@@ -301,7 +301,7 @@ func (cli *CLI) Run(args []string) int {
 	// Write LICENSE body to file
 	_, err = io.Copy(licenseWriter, strings.NewReader(body))
 	if err != nil {
-		cli.errorf("Failed to write license body to %q: %s\n", output, err.Error())
+		cli.errorf("Failed to write license body to %q: %s\n", output, err)
 		return ExitCodeError
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -198,9 +198,9 @@ func (cli *CLI) Run(args []string) int {
 		}
 	}
 
-	// Show all LICENSE available and ask an user to select.
+	// Show all LICENSE available and ask a user to select.
 	if len(key) == 0 {
-		Debugf("Show all LICENSE available and ask an user to select")
+		Debugf("Show all LICENSE available and ask a user to select")
 
 		list, err := fetchLicenseList()
 		if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -374,12 +374,12 @@ func (cli *CLI) errorf(format string, a ...interface{}) (n int, err error) {
 var helpText = `Usage: license [option] [KEY]
 
   Generate LICENSE file. If you provide KEY, it will try to get LICENSE by
-  it. If you don't provide it, it will ask you to choose from avairable list.
-  You can check avairable LICESE list by '-list' option.
+  it. If you don't provide it, it will ask you to choose from available list.
+  You can check available LICESE list by '-list' option.
 
 Options:
 
-  -list               Show all avairable LICENSE list and quit.
+  -list               Show all available LICENSE list and quit.
                       It will fetch information from GitHub.
 
   -choose             Choose LICENSE like http://choosealicense.com/

--- a/cli.go
+++ b/cli.go
@@ -233,7 +233,9 @@ func (cli *CLI) Run(args []string) int {
 			return ExitCodeError
 		}
 
-		key = *(list[num-1]).Key
+		l := list[num-1]
+		key = *l.Key
+		fmt.Fprintf(cli.outStream, "You chose %#q.\n", *l.Name)
 	}
 
 	home, err := homedir.Dir()

--- a/cli.go
+++ b/cli.go
@@ -88,7 +88,7 @@ func (cli *CLI) Run(args []string) int {
 	// This is only for dev (and test)
 	flListkeys := flags.Bool("list-keys", false, "")
 
-	// Parse commandline flag
+	// Parse commandline flags
 	if err := flags.Parse(args[1:]); err != nil {
 		return ExitCodeError
 	}
@@ -116,14 +116,14 @@ func (cli *CLI) Run(args []string) int {
 		Debugf("Run as DEBUG mode")
 	}
 
-	// Show list of LICENSE and quit
+	// Show a list of LICENSE and quit
 	if *flList || *flListkeys {
 		Debugf("Show list of LICENSE")
 
 		// Create default client
 		client := github.NewClient(nil)
 
-		// Fetch list from Github API
+		// Fetch list from GitHub API
 		list, res, err := client.Licenses.List(context.Background())
 		if err != nil {
 			fmt.Fprintf(cli.errStream, "Failed to fetch LICENSE list: %s\n", err.Error())
@@ -193,9 +193,9 @@ func (cli *CLI) Run(args []string) int {
 		}
 	}
 
-	// Show all LICENSE available and ask user to select.
+	// Show all LICENSE available and ask an user to select.
 	if len(key) == 0 {
-		Debugf("Show all LICENSE available and ask user to select")
+		Debugf("Show all LICENSE available and ask an user to select")
 
 		list, err := fetchLicenseList()
 		if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -204,7 +204,7 @@ func (cli *CLI) Run(args []string) int {
 
 		list, err := fetchLicenseList()
 		if err != nil {
-			cli.errorf("Failed to show LICENSE list: %s", err)
+			cli.errorf("Failed to show LICENSE list: %s\n", err)
 			return ExitCodeError
 		}
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -31,6 +31,7 @@ func TestRun_listFlag(t *testing.T) {
 	status := cli.Run(args)
 	if status != ExitCodeOK {
 		t.Errorf("expected %d to eq %d", status, ExitCodeOK)
+		t.Logf("stderr: %s", errStream.String())
 	}
 }
 
@@ -42,5 +43,6 @@ func TestRun_chooseFlag(t *testing.T) {
 	status := cli.Run(args)
 	if status != ExitCodeOK {
 		t.Errorf("expected %d to eq %d", status, ExitCodeOK)
+		t.Logf("stderr: %s", errStream.String())
 	}
 }

--- a/github.go
+++ b/github.go
@@ -12,7 +12,7 @@ func fetchLicenseList() ([]*github.License, error) {
 	// Create default client
 	client := github.NewClient(nil)
 
-	// Fetch list of LICENSE from Github API
+	// Fetch a list of LICENSEs from GitHub API
 	list, res, err := client.Licenses.List(context.Background())
 	if err != nil {
 		return nil, err
@@ -25,14 +25,14 @@ func fetchLicenseList() ([]*github.License, error) {
 	return list, nil
 }
 
-// fetchLicense fetches LICENSE file from Github API.
-// if something wrong returns error.
+// fetchLicense fetches a LICENSE file from GitHub API.
+// If something is wrong, it returns the error.
 func fetchLicense(key string) (string, error) {
 
 	// Create default client
 	client := github.NewClient(nil)
 
-	// Fetch a LICENSE from Github API
+	// Fetch a LICENSE from GitHub API
 	Debugf("Fetch license from GitHub API by key: %s", key)
 	license, res, err := client.Licenses.Get(context.Background(), key)
 	if err != nil {

--- a/input_ui.go
+++ b/input_ui.go
@@ -137,12 +137,13 @@ func (cli CLI) askString(query string, defaultStr string) (<-chan string, <-chan
 		cli.errorf("%s [default: %s] ", query, defaultStr)
 
 		reader := bufio.NewReader(os.Stdin)
-		b, _, err := reader.ReadLine()
+		line, err := reader.ReadString('\n')
 		if err != nil {
+			fmt.Fprintln(cli.outStream)
 			errCh <- &askError{kind: scanError, err: err}
 			return
 		}
-		line := string(b)
+		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
 		Debugf("Input: %q", line)
 
 		// Use Default value

--- a/input_ui.go
+++ b/input_ui.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mitchellh/colorstring"
 )
 
+var errInterrupt = errors.New("interrupted")
+
 // AskNumber asks user to choose number from 1 to max
 func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
 
@@ -24,7 +26,8 @@ func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
 
 	select {
 	case <-sigCh:
-		return -1, fmt.Errorf("interrupted")
+		fmt.Fprintln(cli.outStream)
+		return -1, errInterrupt
 	case num := <-result:
 		return num, nil
 	case err := <-errCh:
@@ -120,7 +123,8 @@ func (cli CLI) AskString(query string, defaultStr string) (string, error) {
 
 	select {
 	case <-sigCh:
-		return "", fmt.Errorf("interrupted")
+		fmt.Fprintln(cli.outStream)
+		return "", errInterrupt
 	case str := <-result:
 		return str, nil
 	case err := <-errCh:
@@ -137,7 +141,7 @@ func (cli CLI) askString(query string, defaultStr string) (<-chan string, <-chan
 		reader := bufio.NewReader(os.Stdin)
 		b, _, err := reader.ReadLine()
 		if err != nil {
-			errCh <- fmt.Errorf("scanning from stdin: %s", err)
+			errCh <- &askError{kind: scanError, err: err}
 			return
 		}
 		line := string(b)

--- a/input_ui.go
+++ b/input_ui.go
@@ -17,7 +17,6 @@ var errInterrupt = errors.New("interrupted")
 
 // AskNumber asks user to choose number from 1 to max
 func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
-
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
@@ -114,7 +113,6 @@ func (cli CLI) askNumber1(max int, defaultNum int) (int, *askError) {
 
 // AskString asks user to input some string
 func (cli CLI) AskString(query string, defaultStr string) (string, error) {
-
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)

--- a/input_ui.go
+++ b/input_ui.go
@@ -153,7 +153,7 @@ func (cli CLI) askString(query string, defaultStr string) (<-chan string, <-chan
 	return result, errCh
 }
 
-func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultReplace, optionValue string) string {
+func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultReplace, optionValue string) (string, error) {
 	// Repalce name if needed
 	folders := findPlaceholders(body, keys)
 
@@ -163,7 +163,11 @@ func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultRep
 			ans = optionValue
 		} else {
 			// Ask or Confirm default value from user
-			ans, _ = cli.AskString(query, defaultReplace)
+			s, err := cli.AskString(query, defaultReplace)
+			if err != nil {
+				return "", err
+			}
+			ans = s
 		}
 
 		if ans != DoNothing {
@@ -174,7 +178,7 @@ func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultRep
 		}
 	}
 
-	return body
+	return body, nil
 }
 
 // Choose shows shows LICENSE description from http://choosealicense.com/

--- a/input_ui.go
+++ b/input_ui.go
@@ -29,7 +29,7 @@ func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
 			if err != nil {
 				Debugf("Failed to scan stdin: %s", err.Error())
 			}
-			line = strings.TrimSuffix(line, "\r\n")
+			line = strings.TrimSpace(line)
 
 			Debugf("Input: %q", line)
 

--- a/input_ui.go
+++ b/input_ui.go
@@ -15,7 +15,7 @@ import (
 
 var errInterrupt = errors.New("interrupted")
 
-// AskNumber asks user to choose number from 1 to max
+// AskNumber asks users to choose a number from 1 to max.
 func (cli CLI) AskNumber(max int, defaultNum int) (int, error) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
@@ -92,7 +92,7 @@ func (cli CLI) askNumber1(max int, defaultNum int) (int, *askError) {
 
 	Debugf("Input: %q", line)
 
-	// Use Default value
+	// Use the default value
 	if line == "" {
 		return defaultNum, nil
 	}
@@ -103,7 +103,7 @@ func (cli CLI) askNumber1(max int, defaultNum int) (int, *askError) {
 		return 0, &askError{kind: invalidInput, err: errors.New("choose by number")}
 	}
 
-	// Check input is in range
+	// Check the input is in range
 	if n < 1 || max < n {
 		return 0, &askError{kind: invalidInput, err: fmt.Errorf("choose from 1 to %d", max)}
 	}
@@ -111,7 +111,7 @@ func (cli CLI) askNumber1(max int, defaultNum int) (int, *askError) {
 	return n, nil
 }
 
-// AskString asks user to input some string
+// AskString asks users to input some string
 func (cli CLI) AskString(query string, defaultStr string) (string, error) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
@@ -156,7 +156,7 @@ func (cli CLI) askString(query string, defaultStr string) (<-chan string, <-chan
 }
 
 func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultReplace, optionValue string) (string, error) {
-	// Repalce name if needed
+	// Replace name if needed
 	folders := findPlaceholders(body, keys)
 
 	if len(folders) > 0 {
@@ -183,9 +183,9 @@ func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultRep
 	return body, nil
 }
 
-// Choose shows shows LICENSE description from http://choosealicense.com/
-// And ask user to choose LICENSE. It returns key to fetch LICENSE file.
-// If something is wrong, return error.
+// Choose shows LICENSE description from http://choosealicense.com/.
+// And ask users to choose LICENSE. It returns key to fetch LICENSE file.
+// If something is wrong, returns error.
 func (cli *CLI) Choose() (string, error) {
 	colorstring.Fprintf(cli.errStream, chooseText)
 
@@ -194,7 +194,7 @@ func (cli *CLI) Choose() (string, error) {
 		return "", err
 	}
 
-	// If user selects 3, should ask user GPL V2 or V3
+	// If the user selects 3, should ask whether GPL V2 or V3
 	if num == 3 {
 		var buf bytes.Buffer
 		buf.WriteString("\n")

--- a/input_ui.go
+++ b/input_ui.go
@@ -184,9 +184,9 @@ func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultRep
 	return body, nil
 }
 
-// Choose shows LICENSE description from http://choosealicense.com/.
-// And ask users to choose LICENSE. It returns key to fetch LICENSE file.
-// If something is wrong, returns error.
+// Choose shows the LICENSE description from http://choosealicense.com/.
+// And it asks users to choose a LICENSE. It returns the key to fetch the
+// LICENSE file. If something is wrong, returns the error.
 func (cli *CLI) Choose() (string, error) {
 	colorstring.Fprintf(cli.errStream, chooseText)
 
@@ -195,7 +195,7 @@ func (cli *CLI) Choose() (string, error) {
 		return "", err
 	}
 
-	// If the user selects 3, should ask whether GPL V2 or V3
+	// If the user selected 3, should ask whether GPL V2 or V3
 	if num == 3 {
 		var buf bytes.Buffer
 		buf.WriteString("\n")

--- a/input_ui.go
+++ b/input_ui.go
@@ -48,7 +48,7 @@ func (cli CLI) askNumber(max int, defaultNum int) (<-chan int, <-chan error) {
 				errCh <- err
 				break
 			}
-			fmt.Fprintf(cli.errStream, "  is an invalid choice: %s.\n\n", err)
+			cli.errorf("  is an invalid choice: %s.\n\n", err)
 		}
 	}()
 	return result, errCh
@@ -81,7 +81,7 @@ func (a *askError) isInvalidInput() bool {
 }
 
 func (cli CLI) askNumber1(max int, defaultNum int) (int, *askError) {
-	fmt.Fprintf(cli.errStream, "Your choice? [default: %d] ", defaultNum)
+	cli.errorf("Your choice? [default: %d] ", defaultNum)
 	reader := bufio.NewReader(os.Stdin)
 	line, err := reader.ReadString('\n')
 	if err != nil {
@@ -134,7 +134,7 @@ func (cli CLI) askString(query string, defaultStr string) (<-chan string, <-chan
 	result := make(chan string, 1)
 	errCh := make(chan error, 1)
 	go func() {
-		fmt.Fprintf(cli.errStream, "%s [default: %s] ", query, defaultStr)
+		cli.errorf("%s [default: %s] ", query, defaultStr)
 
 		reader := bufio.NewReader(os.Stdin)
 		b, _, err := reader.ReadLine()
@@ -174,7 +174,7 @@ func (cli *CLI) ReplacePlaceholder(body string, keys []string, query, defaultRep
 
 		if ans != DoNothing {
 			for _, f := range folders {
-				fmt.Fprintf(cli.errStream, "----> Replace placeholder %q to %q in LICENSE body\n", f, ans)
+				cli.errorf("----> Replace placeholder %q to %q in LICENSE body\n", f, ans)
 				body = strings.Replace(body, f, ans, -1)
 			}
 		}
@@ -201,7 +201,7 @@ func (cli *CLI) Choose() (string, error) {
 		buf.WriteString("Which version do you want?\n")
 		buf.WriteString("  1) V2\n")
 		buf.WriteString("  2) V3\n")
-		fmt.Fprintf(cli.errStream, buf.String())
+		cli.errorf(buf.String())
 
 		num, err = cli.AskNumber(2, 1)
 		if err != nil {

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Generate all avairable licenses
+# Generate all available licenses
 set -e
 
 DIR=$(cd $(dirname ${0})/.. && pwd)


### PR DESCRIPTION
## User Interface improvements

### Number input
- remove leading and trailing whitespace
- on the non-Windows environments, there was a bug where the input's trailing `\n` is not removed
### Both number & string input
- abort dialog if scanning from `stdin` failed
- properly put a newline if scanning failed
- Ctrl-D, which causes EOF, comes to end up a user input
### Main program
- delay creating an output file and, if any, its parent directory so that when replacement generates any error, any files and directories are not created
- correct a number that the `MIT` license is assigned: as it was, it caused panic
- let users know the names of the licenses after they input a number; this change makes them assured because users may mistakenly input an accidental number

## Others

- arrange some outputs mainly when they report errors
- fix typos
- refactor

## Notes

- #6 is seemingly correct, but actually `bufio.ReadLine` ignores `EOF` if some bytes are already read
  (e.g., when a user types `abc<C-d><C-d>`, where `<C-d>` is Ctrl-D, the `<C-d>` behaves as if it is the `enter` key; `abc` is returned and `error` is `nil`)